### PR TITLE
use System.getProperty("user.home")

### DIFF
--- a/kuberig-core/src/main/kotlin/io/kuberig/kubectl/KubectlConfigReader.kt
+++ b/kuberig-core/src/main/kotlin/io/kuberig/kubectl/KubectlConfigReader.kt
@@ -59,7 +59,7 @@ class KubectlConfigReader {
         objectMapper.registerModule(byteArrayModule)
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT)
 
-        val configFileLocation = System.getenv("KUBECONFIG") ?: "${System.getenv("HOME")}/.kube/config"
+        val configFileLocation = System.getenv("KUBECONFIG") ?: "${System.getProperty("user.home")}/.kube/config"
 
         val configFile = File(configFileLocation)
 


### PR DESCRIPTION
Hi
I believe `user.home` would work everywhere.
I had `null` there on win 10